### PR TITLE
Update for new plymouth themes path

### DIFF
--- a/src/endlessos.plymouth
+++ b/src/endlessos.plymouth
@@ -4,5 +4,5 @@ Description=EndlessOS Plymouth Theme
 ModuleName=script
 
 [script]
-ImageDir=/lib/plymouth/themes/endlessos
-ScriptFile=/lib/plymouth/themes/endlessos/endlessos.script
+ImageDir=/usr/share/plymouth/themes/endlessos
+ScriptFile=/usr/share/plymouth/themes/endlessos/endlessos.script


### PR DESCRIPTION
In the latest version of plymouth (the one shipped in our distro),
themes now live in /usr/share/plymouth/themes.

[endlessm/eos-shell#1242]
